### PR TITLE
Fix issue with duplicate generators

### DIFF
--- a/src/pudl/analysis/allocate_gen_fuel.py
+++ b/src/pudl/analysis/allocate_gen_fuel.py
@@ -837,7 +837,7 @@ def remove_inactive_generators(gen_assoc: pd.DataFrame) -> pd.DataFrame:
             proposed_plants,
             unassociated_plants,
         ]
-    )
+    ).drop_duplciates(keep="first")
 
     return gen_assoc_removed
 
@@ -1323,8 +1323,7 @@ def allocate_gen_fuel_by_gen_esc(gen_pm_fuel: pd.DataFrame) -> pd.DataFrame:
         net_gen_alloc.assign(
             # we could x.net_generation_mwh_g_tbl.fillna here if we wanted to
             # take the net gen
-            net_generation_mwh=lambda x: x.net_generation_mwh_gf_tbl
-            * x.frac,
+            net_generation_mwh=lambda x: x.net_generation_mwh_gf_tbl * x.frac,
         )
         .pipe(apply_pudl_dtypes, group="eia")
         .dropna(how="all")


### PR DESCRIPTION
When running the `pudl.analysis.allocate_gen_fuel` pipeline for 2016 and 2017, we were getting a `TypeError` at `group_duplicate_keys()`, because this function was trying to `groupby().sum()` non-numeric columns like `generator_retirement_date`. 

The `group_duplicate_keys()` will only work if we drop any datetime and boolean columns before using this function, and considering carefully whether we want to sum any of the `frac` columns or not. This PR, however, does not touch this function, but rather fixes the issue upstream. 

We were only running into this issue with `group_duplicate_keys()` because there were duplicate keys in the dataframe, so this PR addresses the root cause of where duplicate keys were getting introduced in the first place.

It turns out that when creating the `gen_assoc` table with `associate_generator_tables()`, one of the steps is `remove_inactive_generators()`, which removes certain generators by creating six different dataframes with different generators based on their operating status: `existing`, retiring_generators, `retired_plants`, `proposed_generators`, `proposed_plants`, and `unassociated_plants`. These six dataframes are then concat'ed together. Previously our assumption was that these six dataframes should be non-overlapping. However, it turns out that this is not always the case. 

For example, in 2016, plant 56846 generator GTG1 ended up in both `proposed_generators` and `proposed_plants`, which was causing it to be duplicated. 

We fix this by simply adding `.drop_duplicates()` after these six dataframes are concat'ed together. This fixes the issue that we were experiencing in 2016 and 2017. 

For now, we will leave `group_duplicate_keys()` alone even though it does not work. It effectively acts as an error if there are ever any duplicate keys since it will raise a typeerror like we saw for 2016 and 2017. 