### PR TITLE
fix misspelled drop_duplicates

### DIFF
--- a/src/pudl/analysis/allocate_gen_fuel.py
+++ b/src/pudl/analysis/allocate_gen_fuel.py
@@ -837,7 +837,7 @@ def remove_inactive_generators(gen_assoc: pd.DataFrame) -> pd.DataFrame:
             proposed_plants,
             unassociated_plants,
         ]
-    ).drop_duplciates(keep="first")
+    ).drop_duplicates(keep="first")
 
     return gen_assoc_removed
 


### PR DESCRIPTION
In https://github.com/singularity-energy/pudl/pull/3 I misspelled `drop_duplicates()`. This PR fixes that.